### PR TITLE
pip 19 needs a cache directory, we still purge it at the end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN \
  echo "**** install pip packages ****" && \
  pip install --no-cache-dir -U \
 	pip && \
- pip install --no-cache-dir -U \
+ pip install -U \
 	cheetah \
 	configparser \
 	ndg-httpsclient \


### PR DESCRIPTION
We need to see what is broken downstream also, only specific packages need the cache directory.